### PR TITLE
Remove title from layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -63,9 +63,6 @@
 
     <div id="page">
           <div id="page-content">
-              <h1>
-                  {{ page.title }}
-              </h1>
               <div id="content">
              {{ content }}
               </div>


### PR DESCRIPTION
Generally the page title is already included in the content itself.